### PR TITLE
fix: remove pattern in Pet proto and add max/minAge in FindAll

### DIFF
--- a/johnjud/backend/pet/v1/pet.proto
+++ b/johnjud/backend/pet/v1/pet.proto
@@ -30,7 +30,7 @@ message Pet{
   string birthdate = 4;
   string gender = 5;
   string color = 6;
-  string pattern = 7;
+  string pattern = 7 [deprecated=true];
   string habit = 8;
   string caption = 9;
   repeated johnjud.file.image.v1.Image images = 10;
@@ -52,10 +52,12 @@ message FindAllPetRequest{
   string gender = 3;
   string color = 4;
   string pattern = 5;
-  string age = 6;
+  string age = 6 [deprecated=true];
   string origin = 7;
   int32 pageSize = 8;
   int32 page = 9;
+  int32 maxAge = 10;
+  int32 minAge = 11;
 }
 
 message FindAllPetResponse{


### PR DESCRIPTION
### fix pet proto
- remove `pattern` in `Pet`
- iirc Tony told me that i should just remove `pattern`

- add `maxAge` and `minAge` in `FindAllPetRequest`, remove `string age`
- from front end page
<img width="243" alt="Screenshot 2024-01-17 at 22 38 07" src="https://github.com/isd-sgcu/johnjud-proto/assets/84141000/59cf8c9e-a5c0-49ea-8e68-875cb4afd9d6">
